### PR TITLE
Fixed the failing tests

### DIFF
--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -9,7 +9,7 @@ class BoardTest < MiniTest::Unit::TestCase
   def mock_serial_port(*args, &block)
     mock_port = MiniTest::Mock.new
     mock_port.expect(:read_timeout=, 2, [2])
-    mock_port.expect(:is_a?, false, [nil])
+    mock_port.expect(:is_a?, false, [String])
 
     if block_given?
       yield mock_port


### PR DESCRIPTION
# What Changed

The test suite
# Why?

It looks like the code was looking for a `String` object so that it could determine if it was going to use a `FakeSerialPort` or a real `SerialPort`. From what I understood about the test code / implementation code, this fix should be accurate. Prior to the fix, the test suite had 10 errors.

Let me know if I was off on this one and I will patch it up accordingly.
