### PR TITLE
removed deprecation warnings for StringIO methods

### DIFF
--- a/lib/firmata/board.rb
+++ b/lib/firmata/board.rb
@@ -149,7 +149,7 @@ module Firmata
     #
     # Returns nothing.
     def process(data)
-      bytes = StringIO.new(String(data)).bytes
+      bytes = StringIO.new(String(data)).each_byte
       bytes.each do |byte|
         case byte
         when REPORT_VERSION

--- a/test/fake_serial_port.rb
+++ b/test/fake_serial_port.rb
@@ -43,7 +43,7 @@ class FakeSerialPort
   alias_method :write_nonblock, :write
 
   def bytes
-    bytes = StringIO.new(@buffer).bytes
+    bytes = StringIO.new(@buffer).each_byte
     @buffer = ""
     bytes
   end


### PR DESCRIPTION
I was getting a lot of deprecation warnings because `.bytes` is deprecated in the `StringIO` class. This pull request changes `bytes` to `each_byte`.
