### PR TITLE
Fix for Firmata 2.3

### DIFF
--- a/lib/firmata/board.rb
+++ b/lib/firmata/board.rb
@@ -354,7 +354,7 @@ module Firmata
     #
     # Returns nothing.
     def query_firmware
-      write(FIRMWARE_QUERY)
+      write(START_SYSEX, FIRMWARE_QUERY, END_SYSEX)
     end
 
     # Public: Ask the Arduino for the current configuration of any pin.


### PR DESCRIPTION
0x79 is part of the SYSEX commands, so it needs to be sent with the START_SYSEX and END_SYSEX bytes. Tested on Elementary OS and working with StandardFirmata 2.3
