### PR TITLE
Update serialport from 1.1.0 => 1.3.1.

### DIFF
--- a/firmata.gemspec
+++ b/firmata.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("pry")
 
-  gem.add_runtime_dependency("serialport", ["~> 1.1.0"])
+  gem.add_runtime_dependency("serialport", ["~> 1.3.1"])
   gem.add_runtime_dependency("event_spitter")
 end


### PR DESCRIPTION
Installing firmata fails using `ruby-2.2.2` due to old version of serialport, so this PR fixes that issue.

Test results:

```
# Running:

..................

Fabulous run in 0.006417s, 2804.8336 runs/s, 2493.1854 assertions/s.

18 runs, 16 assertions, 0 failures, 0 errors, 0 skips
```
